### PR TITLE
button color change and permalink fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Permalinks
-permalink:      /:year-:month-:day/:title
+permalink:      /:year-:month-:day/:title.html
 
 # Setup
 title:          Hackatony
@@ -27,5 +27,5 @@ github:
   repo:         https://github.com/damjes/hackaton1
 
 # Gems
-plugins:
+gems:
   - jekyll-paginate

--- a/styles.scss
+++ b/styles.scss
@@ -31,17 +31,17 @@ div.chefa-menuo a {
 }
 
 a.vizaghlibro {
-	background-color: navy;
+	background-color: #3b5998; //same color as fb uses
 }
 
 a.loko {
-	background-color: black;
+	background-color: #231f20; //same color as in loko logo
 }
 
 a.ideo {
-	background-color: green;
+	background-color: #00B224; //chose with color wheel as complementary to afisho bg color
 }
 
 a.afisho {
-	background-color: red;
+	background-color: #B20A22; //chosen with color wheel as complementary to ideo bg color
 }


### PR DESCRIPTION
When applied it changes background colors of four buttons on index page to more greyish.
And adds `.html` to default post permalinks. 
Changes section name `plugins:` in `_config.yml` to `gems:` **this maybe incorrect depending on the version of jekyll used.**